### PR TITLE
fix: changed literal strings to variables in shell expansion

### DIFF
--- a/yt-transcribe
+++ b/yt-transcribe
@@ -190,8 +190,8 @@ fi
 
 # Create an HTML file to display. We'll add the text of the talk in the
 # next branch
-htmldir="${outdir:-yttranscribe_cache_folder}"
-transcript_html="${htmldir}/${outfile:-yturl_clean.html}"
+htmldir="${outdir:-$yttranscribe_cache_folder}"
+transcript_html="${htmldir}/${outfile:-$yturl_clean.html}"
 cat <<EOF >"$transcript_html"
 <html><head>
 <meta charset="utf-8">


### PR DESCRIPTION
When I tried it w/o specifying an outdir it errored out and this is why:

```bash
htmldir="${outdir:-yttranscribe_cache_folder}"
transcript_html="${htmldir}/${outfile:-yturl_clean.html}"
```

the the `-` values are literal strings, not variables.

This PR just changes those to:

```bash
htmldir="${outdir:-$yttranscribe_cache_folder}"
transcript_html="${htmldir}/${outfile:-$yturl_clean.html}"
```